### PR TITLE
fix: Build JupyterLab extensions in postBuild

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,2 +1,6 @@
 python -m pip install --no-cache-dir -r requirements.txt
 python -m pip install --no-cache-dir -r book/requirements.txt
+jupyter labextension install jupyterlab-jupytext --no-build
+jupyter labextension install nbdime-jupyterlab --no-build
+jupyter lab build -y
+jupyter lab clean -y


### PR DESCRIPTION
Build the required JupyterLab extensions in `postBuild` to avoid getting a warning upon entering JupyterLab on Binder launch (mentioned by @cranmer in PR #1).

Example: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/cranmer/stats-ds-book/master?urlpath=lab/tree/book)
