### PR TITLE
fix: Remove restrictions on myst related dependencies provided by jupyter-book

### DIFF
--- a/book/requirements.txt
+++ b/book/requirements.txt
@@ -16,9 +16,7 @@ pyhf
 plotly
 bokeh
 altair
-jupytext[myst]
-myst-nb~=0.8.5
-myst-parser~=0.11.1  # Restrict range to satisfy myst-nb
+jupytext
 sphinx-click
 sphinx-tabs
 sphinx-panels


### PR DESCRIPTION
@cranmer I'm not sure why you have any `myst` related dependencies defined, as they should all be covered when `jupyter-book` installs what is needed. Unless you explicitly need versions that differ from what `jupyter-book` installs then including them will inevitably lead to conflicts.

It is clear this is already going to be the case given that [`jupytext[myst]` is going to restrict `myst-parser`](https://github.com/mwouts/jupytext/blob/aeb2cf6d49606311c8695dd63a56428fd9b0c01c/setup.py#L57-L58) in ways that `jupyter-book` might not want. I'd just [let `jupyter-book` sort it out](https://github.com/executablebooks/jupyter-book/blob/4904f7021fb9a7488327343a1645c1d36923b7b8/CHANGELOG.md#v075-2020-08-26).